### PR TITLE
ssmからDB名などを取得する方法を修正

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -9,7 +9,7 @@ Parameters:
 
   DatabaseUser:
     NoEcho: true
-    Type: AWS::SSM::Parameter::Value<String>
+    Type: AWS::SSM::Parameter::Name
     Description: Database admin account name
     MinLength: 5
     MaxLength: 16
@@ -18,7 +18,7 @@ Parameters:
 
   DatabasePassword:
     NoEcho: true
-    Type: AWS::SSM::Parameter::Value<String>
+    Type: AWS::SSM::Parameter::Name
     Description: Database admin account password
     MinLength: 6
     MaxLength: 41
@@ -27,7 +27,7 @@ Parameters:
 
   DatabaseName:
     NoEcho: true
-    Type: AWS::SSM::Parameter::Value<String>
+    Type: AWS::SSM::Parameter::Name
     Description: Database name
     MinLength: 1
     MaxLength: 30
@@ -220,9 +220,9 @@ Resources:
       VPCSecurityGroups:
         - !Ref DatabaseSecurityGroup
       Engine: !Ref DatabaseEngine
-      DBName: !Ref DatabaseName
-      MasterUsername: !Ref DatabaseUser
-      MasterUserPassword: !Ref DatabasePassword
+      DBName: !Sub '{{resolve:ssm:${DatabaseName}:1}}'
+      MasterUsername: !Sub '{{resolve:ssm:${DatabaseUser}:1}}'
+      MasterUserPassword: !Sub '{{resolve:ssm-secure:${DatabasePassword}:1}}'
       DBInstanceClass: !Ref DatabaseInstanceClass
       AllocatedStorage: !Ref DatabaseSize
       StorageType: gp2


### PR DESCRIPTION
○修正内容
- DB名、DBユーザー名、DBパスワードの取得方法を変更
- パラメータストアのSecure Stringに対応しているMasterUserPasswordのみssm-secureで取得
※詳細はドキュメントを参照
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html